### PR TITLE
Fix boolean column value always coming false in csv import

### DIFF
--- a/lib/flextures/flextures_loader.rb
+++ b/lib/flextures/flextures_loader.rb
@@ -36,7 +36,7 @@ module Flextures
       },
       boolean:->(d){
         return d if d.nil?
-        !(0==d || ""==d || !d)
+        !("false"==d || "0"==d || ""==d || 0==d || !d)
       },
       date:->(d){
         return d   if d.nil?

--- a/test/unit/test_flextures_loader.rb
+++ b/test/unit/test_flextures_loader.rb
@@ -12,22 +12,34 @@ class FlexturesLoaderTest < Test::Unit::TestCase
         should "'nil' value not changed" do
           assert_equal nil, Flextures::Loader::TRANSLATER[:boolean].call(nil)
         end
-        should "'true' value not changed" do
+        should "true value not changed" do
           assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call(true)
         end
-        should "'false' value not changed" do
+        should "false value not changed" do
           assert_equal false, Flextures::Loader::TRANSLATER[:boolean].call(false)
         end
-        should "'0' is change to 'false'" do
+        should "0 is change to 'false'" do
           assert_equal false, Flextures::Loader::TRANSLATER[:boolean].call(0)
         end
-        should "'1' is change to 'true'" do
+        should "1 is change to 'true'" do
           assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call(1)
         end
-        should "'-1' is change to 'true'" do
+        should "-1 is change to 'true'" do
           assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call(-1)
         end
-        should "'string data' is change to 'true'" do
+        should "'0' is change to 'false'" do
+          assert_equal false, Flextures::Loader::TRANSLATER[:boolean].call('0')
+        end
+        should "'1' is change to 'true'" do
+          assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call('1')
+        end
+        should "'true' value not changed" do
+          assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call('true')
+        end
+        should "'false' value not changed" do
+          assert_equal false, Flextures::Loader::TRANSLATER[:boolean].call('false')
+        end
+        should "'non-falsy string data' is change to 'true'" do
           assert_equal true, Flextures::Loader::TRANSLATER[:boolean].call("Hello")
         end
         should "'empty string' is change to 'true'" do


### PR DESCRIPTION
`rake db:flextures:dump`でbooleanのカラムをCSVにダンプすると`true` `false`のような文字列で書き出されます。
このCSVを`rake db:flextures:load`でロードすると値が`false`であってもすべて`true`として登録されてしまうみたいです。また、CSVにbooleanカラムの値をfalseを意図して`0`と記述していた場合、意図した値が設定されないようです。
